### PR TITLE
11.0 fix/buildout reporting engine

### DIFF
--- a/buildout/base-produto.cfg
+++ b/buildout/base-produto.cfg
@@ -175,7 +175,7 @@ github_addon_list =
 [addons_version]
 #server-tools=kmee 11.0
 #web=kmee 11.0
-#reporting-engine=kmee 11.0
+reporting-engine=kmee 11.0-mig-report_xlsx
 #bank-payment=kmee 11.0
 l10n-brazil=kmee 11.0-develop
 #report-print-send=kmee 11.0

--- a/init-buildout.sh
+++ b/init-buildout.sh
@@ -2,5 +2,5 @@
 set -e -x
 virtualenv -p python3 .
 bin/pip install -U zc.buildout==2.8.0 pip
-bin/buildout
+bin/buildout -c buildout/base-produto.cfg
 


### PR DESCRIPTION
Foi adicionado o parâmetro "-c buildout/base-produto.cfg" no buildout.
Foi adicionado o reporting-engine no buildout pela branch "11.0-mig-report_xlsx"